### PR TITLE
Add MiniMax provider configuration

### DIFF
--- a/crates/backend/src/session/mod.rs
+++ b/crates/backend/src/session/mod.rs
@@ -65,10 +65,17 @@ impl SessionEnvironment {
         );
         println!("🔧 [HANDSHAKE] Using API key (security delegated to CLI)");
 
-        match config.provider.as_str() {
+        match llxprt_provider_name(config) {
             "anthropic" => {
                 guards.push(EnvVarGuard::new("ANTHROPIC_API_KEY", &config.api_key));
                 println!("🔧 [HANDSHAKE] Set ANTHROPIC_API_KEY");
+
+                if let Some(url) = &config.base_url
+                    && !url.trim().is_empty()
+                {
+                    guards.push(EnvVarGuard::new("ANTHROPIC_BASE_URL", url));
+                    println!("🔧 [HANDSHAKE] Set ANTHROPIC_BASE_URL");
+                }
             }
             "openai" | "openrouter" => {
                 guards.push(EnvVarGuard::new("OPENAI_API_KEY", &config.api_key));
@@ -194,6 +201,14 @@ pub struct LLxprtConfig {
     pub api_key: String,
     pub model: String,
     pub base_url: Option<String>, // For custom/self-hosted providers
+}
+
+fn llxprt_provider_name(config: &LLxprtConfig) -> &str {
+    match config.provider.as_str() {
+        "openrouter" | "minimax" => "openai",
+        "minimax-anthropic" => "anthropic",
+        provider => provider,
+    }
 }
 
 use crate::acp::{
@@ -634,12 +649,7 @@ pub async fn initialize_session<E: EventEmitter + 'static>(
     // Build command based on backend type
     let mut cmd = {
         if let Some(config) = &llxprt_config {
-            // Map UI provider names to LLxprt provider names
-            // OpenRouter is actually "openai" provider with custom base URL
-            let llxprt_provider = match config.provider.as_str() {
-                "openrouter" => "openai",
-                other => other,
-            };
+            let llxprt_provider = llxprt_provider_name(config);
 
             // Build command with --provider and --model flags
             let has_base_url = config
@@ -2495,6 +2505,63 @@ mod tests {
         std::thread::sleep(std::time::Duration::from_millis(10));
         assert!(std::env::var(key_var).is_err());
         assert!(std::env::var(url_var).is_err());
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn test_session_environment_llxprt_minimax_endpoints() {
+        let cases = [
+            (
+                "minimax",
+                "openai",
+                "mm-open",
+                "https://api.minimaxi.com/v1",
+                "OPENAI_API_KEY",
+                "OPENAI_BASE_URL",
+                "ANTHROPIC_API_KEY",
+                "ANTHROPIC_BASE_URL",
+            ),
+            (
+                "minimax-anthropic",
+                "anthropic",
+                "mm-anth",
+                "https://api.minimaxi.com/anthropic",
+                "ANTHROPIC_API_KEY",
+                "ANTHROPIC_BASE_URL",
+                "OPENAI_API_KEY",
+                "OPENAI_BASE_URL",
+            ),
+        ];
+
+        for (provider, llxprt_provider, api_key, url, key_var, url_var, other_key, other_url) in
+            cases
+        {
+            unsafe {
+                std::env::remove_var(key_var);
+                std::env::remove_var(url_var);
+                std::env::remove_var(other_key);
+                std::env::remove_var(other_url);
+            }
+
+            let config = LLxprtConfig {
+                provider: provider.to_string(),
+                api_key: api_key.to_string(),
+                model: "MiniMax-M3".to_string(),
+                base_url: Some(url.to_string()),
+            };
+
+            assert_eq!(llxprt_provider_name(&config), llxprt_provider);
+            {
+                let _env = SessionEnvironment::setup_llxprt(&config).unwrap();
+                assert_eq!(std::env::var(key_var).unwrap(), api_key);
+                assert_eq!(std::env::var(url_var).unwrap(), url);
+                assert!(std::env::var(other_key).is_err());
+                assert!(std::env::var(other_url).is_err());
+            }
+
+            assert!(std::env::var(key_var).is_err());
+            assert!(std::env::var(url_var).is_err());
+        }
     }
 
     #[test]

--- a/frontend/src/components/common/SettingsDialog.tsx
+++ b/frontend/src/components/common/SettingsDialog.tsx
@@ -45,7 +45,16 @@ import {
 } from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
 import { useBackend, useBackendConfig } from "@/contexts/BackendContext";
-import { GeminiAuthMethod, LLxprtProvider } from "@/types/backend";
+import {
+  GeminiAuthMethod,
+  LLxprtApiFormat,
+  LLxprtProvider,
+  LLxprtRegion,
+} from "@/types/backend";
+import {
+  getMiniMaxEndpoint,
+  MINIMAX_DEFAULT_MODEL,
+} from "@/utils/providerConfig";
 import { supportedLanguages, languageNames } from "@/i18n";
 
 interface OpenRouterModel {
@@ -73,6 +82,8 @@ export const SettingsDialog: React.FC<SettingsDialogProps> = ({
     useBackendConfig("gemini");
   const { config: llxprtConfig, updateConfig: updateLLxprtConfig } =
     useBackendConfig("llxprt");
+  const minimaxApiFormat = llxprtConfig.apiFormat ?? "openai";
+  const minimaxRegion = llxprtConfig.region ?? "global";
 
   // State for OpenRouter model fetching
   const [openRouterModels, setOpenRouterModels] = useState<OpenRouterModel[]>(
@@ -626,7 +637,15 @@ export const SettingsDialog: React.FC<SettingsDialogProps> = ({
                       provider: value as LLxprtProvider,
                     };
 
-                    if (value === "openrouter") {
+                    if (value === "minimax") {
+                      const apiFormat: LLxprtApiFormat = "openai";
+                      const region: LLxprtRegion = "global";
+                      updates.apiFormat = apiFormat;
+                      updates.region = region;
+                      updates.baseUrl = getMiniMaxEndpoint(region, apiFormat);
+                      updates.model = MINIMAX_DEFAULT_MODEL;
+                      onModelChange?.(MINIMAX_DEFAULT_MODEL);
+                    } else if (value === "openrouter") {
                       updates.baseUrl = "https://openrouter.ai/api/v1";
                     } else if (
                       [
@@ -662,6 +681,7 @@ export const SettingsDialog: React.FC<SettingsDialogProps> = ({
                     <SelectItem value="groq">Groq</SelectItem>
                     <SelectItem value="together">Together AI</SelectItem>
                     <SelectItem value="xai">xAI (Grok)</SelectItem>
+                    <SelectItem value="minimax">MiniMax</SelectItem>
                     <SelectItem value="custom">
                       Custom OpenAI-compatible
                     </SelectItem>
@@ -685,6 +705,83 @@ export const SettingsDialog: React.FC<SettingsDialogProps> = ({
                   placeholder="sk-..."
                 />
               </div>
+
+              {/* MiniMax endpoint configuration */}
+              {llxprtConfig.provider === "minimax" && (
+                <div className="space-y-3 rounded-md border border-gray-200 p-3 dark:border-gray-700">
+                  <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+                    <div>
+                      <label className="text-xs font-medium text-gray-600 dark:text-gray-400 mb-1 block">
+                        API compatibility
+                      </label>
+                      <Select
+                        value={minimaxApiFormat}
+                        onValueChange={(value) => {
+                          const apiFormat = value as LLxprtApiFormat;
+                          updateLLxprtConfig({
+                            apiFormat,
+                            baseUrl: getMiniMaxEndpoint(
+                              minimaxRegion,
+                              apiFormat
+                            ),
+                          });
+                        }}
+                      >
+                        <SelectTrigger className="w-full">
+                          <SelectValue />
+                        </SelectTrigger>
+                        <SelectContent>
+                          <SelectItem value="openai">
+                            OpenAI-compatible
+                          </SelectItem>
+                          <SelectItem value="anthropic">
+                            Anthropic-compatible
+                          </SelectItem>
+                        </SelectContent>
+                      </Select>
+                    </div>
+                    <div>
+                      <label className="text-xs font-medium text-gray-600 dark:text-gray-400 mb-1 block">
+                        Region
+                      </label>
+                      <Select
+                        value={minimaxRegion}
+                        onValueChange={(value) => {
+                          const region = value as LLxprtRegion;
+                          updateLLxprtConfig({
+                            region,
+                            baseUrl: getMiniMaxEndpoint(
+                              region,
+                              minimaxApiFormat
+                            ),
+                          });
+                        }}
+                      >
+                        <SelectTrigger className="w-full">
+                          <SelectValue />
+                        </SelectTrigger>
+                        <SelectContent>
+                          <SelectItem value="global">Global</SelectItem>
+                          <SelectItem value="cn">China (CN)</SelectItem>
+                        </SelectContent>
+                      </Select>
+                    </div>
+                  </div>
+                  <div>
+                    <label className="text-xs font-medium text-gray-600 dark:text-gray-400 mb-1 block">
+                      Endpoint URL
+                    </label>
+                    <Input
+                      type="text"
+                      readOnly
+                      value={getMiniMaxEndpoint(
+                        minimaxRegion,
+                        minimaxApiFormat
+                      )}
+                    />
+                  </div>
+                </div>
+              )}
 
               {/* Model */}
               <div>
@@ -799,7 +896,9 @@ export const SettingsDialog: React.FC<SettingsDialogProps> = ({
                                     ? "meta-llama/Llama-3-70b-chat-hf"
                                     : llxprtConfig.provider === "xai"
                                       ? "grok-beta"
-                                      : "model-name"
+                                      : llxprtConfig.provider === "minimax"
+                                        ? MINIMAX_DEFAULT_MODEL
+                                        : "model-name"
                     }
                   />
                 )}

--- a/frontend/src/contexts/BackendContext.tsx
+++ b/frontend/src/contexts/BackendContext.tsx
@@ -17,6 +17,7 @@ import {
   LLxprtConfig,
 } from "../types/backend";
 import { defaultBackendState } from "../utils/backendDefaults";
+import { getMiniMaxEndpoint } from "../utils/providerConfig";
 
 const BackendContext = createContext<BackendContextValue | undefined>(
   undefined
@@ -240,9 +241,16 @@ export const BackendProvider: React.FC<BackendProviderProps> = ({
         }
       } else if (state.selectedBackend === "llxprt") {
         const llxprtConfig = state.configs.llxprt;
+        const baseUrl =
+          llxprtConfig.provider === "minimax"
+            ? getMiniMaxEndpoint(
+                llxprtConfig.region ?? "global",
+                llxprtConfig.apiFormat ?? "openai"
+              )
+            : llxprtConfig.baseUrl || undefined;
         return {
           api_key: llxprtConfig.apiKey,
-          base_url: llxprtConfig.baseUrl || undefined,
+          base_url: baseUrl,
           model: llxprtConfig.model,
         };
       } else if (state.selectedBackend === "gemini") {

--- a/frontend/src/hooks/useMessageHandler.ts
+++ b/frontend/src/hooks/useMessageHandler.ts
@@ -2,6 +2,7 @@ import React, { useState, useCallback } from "react";
 import { api } from "../lib/api";
 import { Message, Conversation } from "../types";
 import { useBackend } from "../contexts/BackendContext";
+import { getMiniMaxEndpoint } from "../utils/providerConfig";
 
 interface UseMessageHandlerProps {
   activeConversation: string | null;
@@ -173,11 +174,23 @@ export const useMessageHandler = ({
           );
         } else if (selectedBackend === "llxprt") {
           const llxprtCfg = backendState.configs.llxprt;
+          const baseUrl =
+            llxprtCfg.provider === "minimax"
+              ? getMiniMaxEndpoint(
+                  llxprtCfg.region ?? "global",
+                  llxprtCfg.apiFormat ?? "openai"
+                )
+              : llxprtCfg.baseUrl || undefined;
+          const provider =
+            llxprtCfg.provider === "minimax" &&
+            (llxprtCfg.apiFormat ?? "openai") === "anthropic"
+              ? "minimax-anthropic"
+              : llxprtCfg.provider;
           llxprtConfig = {
-            provider: llxprtCfg.provider,
+            provider,
             api_key: llxprtCfg.apiKey,
             model: llxprtCfg.model,
-            base_url: llxprtCfg.baseUrl || undefined,
+            base_url: baseUrl,
           };
           console.log(
             "🔍 [useMessageHandler] Setting llxprt_config for LLxprt:",

--- a/frontend/src/types/backend.ts
+++ b/frontend/src/types/backend.ts
@@ -38,7 +38,11 @@ export type LLxprtProvider =
   | "groq"
   | "together"
   | "xai"
+  | "minimax"
   | "custom";
+
+export type LLxprtApiFormat = "openai" | "anthropic";
+export type LLxprtRegion = "global" | "cn";
 
 export interface LLxprtConfig {
   type: "llxprt";
@@ -46,6 +50,8 @@ export interface LLxprtConfig {
   apiKey: string;
   model: string;
   baseUrl: string;
+  apiFormat?: LLxprtApiFormat;
+  region?: LLxprtRegion;
 }
 
 // Type guard for LLxprtConfig
@@ -59,6 +65,7 @@ export function isLLxprtConfig(config: unknown): config is LLxprtConfig {
     "groq",
     "together",
     "xai",
+    "minimax",
     "custom",
   ];
 

--- a/frontend/src/utils/backendDefaults.ts
+++ b/frontend/src/utils/backendDefaults.ts
@@ -4,6 +4,7 @@ import {
   QwenConfig,
   LLxprtConfig,
 } from "../types/backend";
+import { getMiniMaxEndpoint, MINIMAX_DEFAULT_MODEL } from "./providerConfig";
 
 export const defaultGeminiConfig: GeminiConfig = {
   type: "gemini",
@@ -84,6 +85,10 @@ export const llxprtProviderDefaults: Record<
   xai: {
     baseUrl: "",
     modelPlaceholder: "grok-beta",
+  },
+  minimax: {
+    baseUrl: getMiniMaxEndpoint(),
+    modelPlaceholder: MINIMAX_DEFAULT_MODEL,
   },
   custom: {
     baseUrl: "https://api.example.com/v1",

--- a/frontend/src/utils/providerConfig.ts
+++ b/frontend/src/utils/providerConfig.ts
@@ -5,6 +5,34 @@
  * This file contains provider metadata, default values, and validation patterns.
  */
 
+import type { LLxprtApiFormat, LLxprtRegion } from "../types/backend";
+
+export const MINIMAX_DEFAULT_MODEL = "MiniMax-M3";
+
+export const MINIMAX_ENDPOINTS: Record<
+  LLxprtRegion,
+  Record<LLxprtApiFormat, string>
+> = {
+  global: {
+    openai: "https://api.minimax.io/v1",
+    anthropic: "https://api.minimax.io/anthropic",
+  },
+  cn: {
+    openai: "https://api.minimaxi.com/v1",
+    anthropic: "https://api.minimaxi.com/anthropic",
+  },
+};
+
+export function getMiniMaxEndpoint(
+  region: LLxprtRegion = "global",
+  apiFormat: LLxprtApiFormat = "openai"
+): string {
+  const normalizedRegion = region === "cn" ? "cn" : "global";
+  const normalizedApiFormat =
+    apiFormat === "anthropic" ? "anthropic" : "openai";
+  return MINIMAX_ENDPOINTS[normalizedRegion][normalizedApiFormat];
+}
+
 export interface ProviderConfig {
   name: string;
   description: string;
@@ -86,6 +114,13 @@ export const PROVIDER_CONFIGS: Record<string, ProviderConfig> = {
     defaultModel: "grok-4-fast",
     getApiKeyUrl: "https://console.x.ai/",
   },
+  minimax: {
+    name: "MiniMax",
+    description: "MiniMax models through OpenAI- or Anthropic-compatible APIs",
+    requiresBaseUrl: true,
+    defaultBaseUrl: MINIMAX_ENDPOINTS.global.openai,
+    defaultModel: MINIMAX_DEFAULT_MODEL,
+  },
   custom: {
     name: "Custom OpenAI-compatible",
     description: "Use any OpenAI-compatible API endpoint",
@@ -164,5 +199,6 @@ export const MODEL_PLACEHOLDERS: Record<string, string> = {
   groq: "llama-3.3-70b-versatile",
   together: "meta-llama/Llama-3-70b-chat-hf",
   xai: "grok-4-fast",
+  minimax: MINIMAX_DEFAULT_MODEL,
   custom: "model-name",
 } as const;


### PR DESCRIPTION
Reason: Add a MiniMax provider preset with selectable global and China API compatibility endpoints.

Changes:
- Add MiniMax to the LLxprt provider configuration with MiniMax-M3 as the default model.
- Let users select the API compatibility mode and region, deriving the matching endpoint URL.
- Route MiniMax sessions through the matching LLxprt provider environment and base URL.

Checks:
- `pnpm lint:ci`
- `pnpm build`
- `cargo fmt --all -- --check`
- `cargo check -p backend --lib`
- `cargo clippy -p backend --lib -- -D warnings`
- Secret scan passed.

Test note:
- `cargo test -p backend test_session_environment_llxprt_minimax_endpoints --lib` is blocked by existing test-only compile errors for missing `RequestToolCallConfirmationResult` and `mask_api_key`; the same errors reproduced before this patch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added MiniMax as a supported provider.
  - Added configuration for global and China regions.
  - Added OpenAI-compatible and Anthropic-compatible API formats.
  - Automatically selects the appropriate endpoint and default model.
  - Added MiniMax settings and model configuration controls.

- **Updates**
  - Improved provider configuration and environment handling for MiniMax and compatible providers.
  - Updated the default Gemini model to Gemini 3.1 Pro Preview.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->